### PR TITLE
Fix deepgram version

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -10,6 +10,6 @@
     "bullmq": "^4.8.3",
     "ioredis": "^5.3.2",
     "yt-dlp-wrap": "^2.8.0",
-    "deepgram": "^5.2.2"
+    "deepgram": "^1.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- pin the `deepgram` dependency in `worker/package.json` to a stable version

## Testing
- `git status --short`